### PR TITLE
Give credit where credit is due.

### DIFF
--- a/app/templates/main.phtml
+++ b/app/templates/main.phtml
@@ -333,7 +333,7 @@ $footer_msg = \Entity\Settings::getSetting('footer_message');
         <? endif; ?>
 
         <p>MLP is copyright &copy; Hasbro. All creations are &copy; to their respective artists. All songs are property of their respective artists.<br>
-            Copyright &copy; 2012-<?=date('Y') ?> <a href="https://poniverse.net/" target="_blank">Poniverse Networks</a>. All rights reserved.</p>
+            Copyright © 2015-<?=date('Y') ?> <a href="https://poniverse.net/" target="_blank">Poniverse Networks</a>. All Rights Reserved. Portions of this site originally copyright © 2012-2015 Bravely Blue Media LLC and Silver Eagle.</p>
     </div>
 </div>
 


### PR DESCRIPTION
It very misleading to claim that Poniverse has copyright dating back to 2012. In fact, _retroactively claiming copyright_ over another entity goes against the very concept of copyright.

I propose that we change the footer to give credit to the project’s original owner/developer @SlvrEagle23 (who has contributed years of hard work putting this site and community together), and to make it clear the @Poniverse does not have copyright dating back to 2012.

Current footer:

> Copyright © 2012-2016 [Poniverse Networks](https://poniverse.net). All rights reserved.

Proposed footer:

> Copyright © 2015-2016 [Poniverse Networks](https://poniverse.net). All Rights Reserved. Portions of this site originally copyright © 2012-2015 Bravely Blue Media LLC and Silver Eagle.

Let me know what you think. This follows the precedent over the transfer of the Node.js project from Joyent to the Node.js Foundation, where the footer of http://nodejs.org states:

> © 2016 Node.js Foundation. All Rights Reserved. Portions of this site originally © 2016 Joyent.
