### PR TITLE
Remove BronyTunes and EqBeats hourly regular sync

### DIFF
--- a/app/library/PVL/SyncManager.php
+++ b/app/library/PVL/SyncManager.php
@@ -99,20 +99,22 @@ class SyncManager
         Debug::runTimer('Run song history cleanup', function() {
             SongHistory::cleanUp();
         });
-
+        
+        /*
         // Sync the BronyTunes library.
         Debug::runTimer('Run BronyTunes sync', function() {
             Service\BronyTunes::load();
         });
+        
+        // Sync the EqBeats library.
+        Debug::runTimer('Run EqBeats sync', function() {
+            Service\EqBeats::load();
+        });
+        */
 
         // Sync the Pony.fm library.
         Debug::runTimer('Run Pony.fm sync', function() {
             Service\PonyFm::load();
-        });
-
-        // Sync the EqBeats library.
-        Debug::runTimer('Run EqBeats sync', function() {
-            Service\EqBeats::load();
         });
 
         Settings::setSetting('sync_slow_last_run', time());


### PR DESCRIPTION
EqBeats is no longer actively in service, so there will be no new changes to the music data already present in the PVL database for it. BronyTunes was largely only included to pull items from the entire MLPMA (which they contained), but with the MLPMA being folded into Pony.fm, it can be used as the sole source for external music records.
